### PR TITLE
fix: error with webpack dynamic require

### DIFF
--- a/lib/zoom_sdk.js
+++ b/lib/zoom_sdk.js
@@ -18,7 +18,9 @@ const ZoomSDK = (() => {
     let clientOpts = opts || {};
     let _path = clientOpts.path || './bin/';
     let zoomnodepath = _path + 'zoomsdk.node';
-    let addon = require(zoomnodepath)();
+    // fix webpack: https://github.com/webpack/webpack/issues/4175#issuecomment-342931035
+    let requireFunc = typeof __webpack_require__ === 'function' ? __non_webpack_require__ : require;
+    let addon = requireFunc(zoomnodepath)();
     let _isSDKInitialized = false;
 
     return {


### PR DESCRIPTION
Error: Cannot find module '**/zoomsdk.node'
      at webpackEmptyContext (**/dist/main/webpack:/node_modules/zoom-sdk-electron/lib sync:2:1)